### PR TITLE
try to fix metadata for repo 'appstream' error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,9 @@ LABEL "com.github.actions.icon"="aperture"
 LABEL "com.github.actions.color"="green"
 
 # hadolint ignore=DL3041
-RUN dnf update --assumeyes \
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-* \
+  && sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-* \
+  && dnf update --assumeyes \
   && dnf install -y epel-release \
   && dnf install --assumeyes \
     ansible git \


### PR DESCRIPTION
```
Error: Failed to download metadata for repo 'appstream': Cannot prepare internal mirrorlist: No URLs in mirrorlist
```

based on https://techglimpse.com/failed-metadata-repo-appstream-centos-8/